### PR TITLE
Add `commit_short_id` & `commit_date` to `GitInfo`

### DIFF
--- a/build-info-build/src/version_control/git.rs
+++ b/build-info-build/src/version_control/git.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 
-use build_info_common::GitInfo;
+use build_info_common::{epoch_to_utc, GitInfo};
 
 use git2::{Oid, Repository, StatusOptions};
 
@@ -28,6 +28,8 @@ pub(crate) fn get_info() -> Result<GitInfo> {
 	}
 	let commit = head.peel_to_commit()?;
 	let commit_id = commit.id();
+	let commit_short_id = commit.as_object().short_id()?.as_str().map(|s| s.to_string());
+	let commit_date = epoch_to_utc(commit.time().seconds()).date().format("%F").to_string();
 
 	let changes = repository.statuses(Some(StatusOptions::new().include_ignored(false)))?;
 	let dirty = !changes.is_empty();
@@ -36,6 +38,8 @@ pub(crate) fn get_info() -> Result<GitInfo> {
 
 	Ok(GitInfo {
 		commit_id: commit_id.to_string(),
+		commit_short_id,
+		commit_date,
 		dirty,
 		branch: if head.is_branch() {
 			head.shorthand().map(|s| s.to_string())

--- a/build-info-common/src/lib.rs
+++ b/build-info-common/src/lib.rs
@@ -124,6 +124,12 @@ pub struct GitInfo {
 	/// Currently checked out git commit hash
 	pub commit_id: String,
 
+	/// Currently checked out short git commit hash
+	pub commit_short_id: Option<String>,
+
+	/// Currently checked out commit date
+	pub commit_date: String,
+
 	/// `true` iff the repository had uncommitted changes when building the project.
 	pub dirty: bool,
 

--- a/build-info-proc/src/format/indexed_string_value.rs
+++ b/build-info-proc/src/format/indexed_string_value.rs
@@ -221,6 +221,8 @@ impl IndexedStringValue for GitInfo {
 		let index = indices.pop_front().unwrap();
 		match index {
 			Index::Field(ref id) if id == "commit_id" => indexed_string_value(&self.commit_id, indices),
+			Index::Field(ref id) if id == "commit_short_id" => indexed_string_value(&self.commit_short_id, indices),
+			Index::Field(ref id) if id == "commit_date" => indexed_string_value(&self.commit_date, indices),
 			Index::Field(ref id) if id == "dirty" => indexed_string_value(&self.dirty, indices),
 			Index::Field(ref id) if id == "branch" => indexed_string_value(&self.branch, indices),
 			Index::Field(ref id) if id == "tags" => indexed_string_value(&self.tags, indices),

--- a/build-info-proc/src/function/init_value.rs
+++ b/build-info-proc/src/function/init_value.rs
@@ -192,6 +192,14 @@ impl InitValue for GitInfo {
 		init_value(&self.commit_id, &mut initializer);
 		initializer.append_all(quote!(,));
 
+		initializer.append_all(quote!(commit_short_id:));
+		init_value(&self.commit_short_id, &mut initializer);
+		initializer.append_all(quote!(,));
+
+		initializer.append_all(quote!(commit_date:));
+		init_value(&self.commit_date, &mut initializer);
+		initializer.append_all(quote!(,));
+
 		initializer.append_all(quote!(dirty:));
 		init_value(&self.dirty, &mut initializer);
 		initializer.append_all(quote!(,));


### PR DESCRIPTION
Hi there, nice work with this group of crates!

I was looking for a solution to replace my "by hand" [version creation code](https://github.com/fnichol/versio/blob/33223718585bf302c9d8e2395e2d1754a018d6c1/build.rs) and it looks like the `GitInfo` has almost everything I'm after, except the short commit ID and the commit date which allows me to print short and long version strings, much like `rustc`, `cargo`, etc. with their `-Vv` invocations.

This change adds a short id for the currently checked out commit and the
date of the commit itself.

Let me know if this approach looks good or if there's anything I can change/improve.

Thanks! 🎉 
