### PR TITLE
remove extra space for env! macro handling

### DIFF
--- a/build-info-proc/src/format/value/macros.rs
+++ b/build-info-proc/src/format/value/macros.rs
@@ -22,7 +22,7 @@ pub(crate) fn call_macro(name: &str, args: &[Box<dyn Value>], span: Span) -> Res
 			abort_if_dirty();
 			Ok(Box::new(result))
 		}
-		"env " => {
+		"env" => {
 			let (name,) = as_arguments_1::<String>(args)?;
 			let value = std::env::var(name).unwrap_or_else(|_| abort!(span, "Environment variable `{}` not defined.", name));
 			Ok(Box::new(value))


### PR DESCRIPTION
`env!` macro did not work in `build_info::format!`, then found this extra space. please apply this fix