### PR TITLE
Made build-info-build not fail on files that it has no permission to

### DIFF
--- a/build-info-build/src/build_script_options/mod.rs
+++ b/build-info-build/src/build_script_options/mod.rs
@@ -137,7 +137,7 @@ fn rebuild_if_project_changes(workspace_root: &str) {
 		},
 	)
 	.unwrap()
-	.map(|source| source.unwrap())
+	.filter_map(|source| source.ok())
 	{
 		println!("cargo:rerun-if-changed={}", source.to_str().unwrap());
 	}


### PR DESCRIPTION
I have a project which has a folder that is not owned by the current user. This makes `build-info-build` fail because it cannot access some of the files and folders.

This change makes `build-info-build` simply ignore the files and folders it has no access to.