### PR TITLE
Allow limiting the depth of dependency collection

### DIFF
--- a/build-info-build/src/build_script_options/mod.rs
+++ b/build-info-build/src/build_script_options/mod.rs
@@ -6,6 +6,7 @@ use build_info_common::{OptimizationLevel, VersionedString};
 use chrono::{DateTime, Utc};
 use xz2::write::XzEncoder;
 
+pub use self::crate_info::DependencyDepth;
 use super::BuildInfo;
 
 mod compiler;
@@ -28,7 +29,7 @@ pub struct BuildScriptOptions {
 	timestamp: Option<DateTime<Utc>>,
 
 	/// Enable dependency collection
-	collect_dependencies: bool,
+	collect_dependencies: DependencyDepth,
 }
 static BUILD_SCRIPT_RAN: AtomicBool = AtomicBool::new(false);
 
@@ -117,7 +118,7 @@ impl Default for BuildScriptOptions {
 		Self {
 			consumed: false,
 			timestamp: None,
-			collect_dependencies: false,
+			collect_dependencies: DependencyDepth::None,
 		}
 	}
 }

--- a/build-info-build/src/lib.rs
+++ b/build-info-build/src/lib.rs
@@ -21,7 +21,7 @@ pub use build_info_common::{
 };
 
 mod build_script_options;
-pub use build_script_options::BuildScriptOptions;
+pub use build_script_options::{BuildScriptOptions, DependencyDepth};
 
 /// Call this function in your `build.rs` script to generate the data consumed by the `build_info` crate.
 /// Additional customization options are available by manipulating the return type.

--- a/dependency-tree/build.rs
+++ b/dependency-tree/build.rs
@@ -1,7 +1,9 @@
+use build_info_build::DependencyDepth;
+
 fn main() {
 	// Calling `build_info_build::build_script` collects all data and makes it available to `build_info::build_info!`
 	// and `build_info::format!` in the main program.
 	//
 	// Dependency collection needs to be enabled specifically.
-	build_info_build::build_script().collect_dependencies(true);
+	build_info_build::build_script().collect_dependencies(DependencyDepth::Full);
 }


### PR DESCRIPTION
For larger rust projects there may be enough nested dependencies that the build script crashes due to a stack overflow.  This allows dependency collection depth to be limited to a chosen depth, no depth, or be unlimited.