### PR TITLE
Fix rerun-if-changed paths for git worktrees

### DIFF
--- a/build-info-build/src/build_script_options/version_control/git.rs
+++ b/build-info-build/src/build_script_options/version_control/git.rs
@@ -16,13 +16,16 @@ pub(crate) fn get_info() -> Result<GitInfo> {
 	if let Some(name) = head.name() {
 		// HEAD has already been added
 		if name != "HEAD" {
-			let path = repository.path().join(name);
+			// Refs and packed-refs live in the common directory, which differs
+			// from path() in a git worktree.
+			let commondir = repository.commondir();
+			let path = commondir.join(name);
 			if path.is_file() {
 				println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
 			} else {
 				println!(
 					"cargo:rerun-if-changed={}",
-					repository.path().join("packed-refs").to_str().unwrap()
+					commondir.join("packed-refs").to_str().unwrap()
 				);
 			}
 		}


### PR DESCRIPTION
Use repository.commondir() instead of repository.path() for ref and packed-refs paths. In a git worktree, path() returns the worktree-specific directory while refs and packed-refs live in the common directory. commondir() returns the same as path() for normal repos, so this is a safe change for both cases.

Fixes #28 